### PR TITLE
Make outlet router primary false

### DIFF
--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -269,5 +269,5 @@ function Outlet() {
     memoizedOutlet = renderRoutes(router.routes)
   }
 
-  return <Router>{memoizedOutlet}</Router>
+  return <Router primary={false}>{memoizedOutlet}</Router>
 }


### PR DESCRIPTION
This tells reach router not to refocus new elements, which is causing that page jumping.