### PR TITLE
Fix TodoApp reset functionality

### DIFF
--- a/src/components/todo-app.js
+++ b/src/components/todo-app.js
@@ -24,11 +24,15 @@ export default function TodoApp() {
           setIsLoading(false)
         }
       })
+  }, [refresh])
+
+  useEffect(() => {
+    isMounted.current = true
 
     return () => {
       isMounted.current = false
     }
-  }, [refresh])
+  })
 
   function addTodo(todo) {
     setNewTodo(null)


### PR DESCRIPTION
When `resetApp` was called, our effect's cleanup function was run, setting `isMounted.current` to `false`. On the next render it was still `false` so the callback logic never ran.

Created a new effect that toggles `isMounted`. Wonder if there's a way we can get rid of this ref though! Feels misaligned with hooks (`isMounted.current` could be `false` even if the component is still on screen.)