### PR TITLE
docs: Add support for constructor options

### DIFF
--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -31,6 +31,9 @@ export default function Api(props) {
     return activeRoute && publicClass.name === activeRoute.label
   })
 
+  let classConstructor = activePublicClass.public.find(({ name }) => name === 'constructor');
+  let hasConstructor = !!classConstructor;
+
   let activeIndex = publicClassRoutes.indexOf(activeRoute)
   let previousPage = activeIndex > 0 ? publicClassRoutes[activeIndex - 1] : null
   let nextPage =
@@ -39,6 +42,7 @@ export default function Api(props) {
       : null
 
   let tableOfContents = [
+    ["Constructor", hasConstructor ? classConstructor.params : []],
     ["Fields", activePublicClass.fields],
     ["Accessors", activePublicClass.accessors],
     ["Methods", activePublicClass.methods],
@@ -47,7 +51,7 @@ export default function Api(props) {
     .reduce((result, [label, members]) => {
       let items = members.map(member => ({
         title: member.name,
-        url: `#${member.slug}`,
+        url: `#${member.slug || member.name}`,
       }))
 
       return [

--- a/src/routes/api/class.tsx
+++ b/src/routes/api/class.tsx
@@ -40,6 +40,7 @@ export default function(props) {
   let classSlug = props.classSlug
   let { publicClasses } = useApiDocs()
   let publicClass = publicClasses.find(doc => doc.slug === classSlug)
+  let classConstructor = publicClass.public.find(({ name }) => name === 'constructor');
 
   return (
     <div>
@@ -47,6 +48,31 @@ export default function(props) {
       <div className="pt-2">
         <Markdown>{publicClass.description}</Markdown>
       </div>
+      {classConstructor ? (
+        <div>
+          <h2
+            id="Constructor"
+            className="font-semibold text-2xl leading-tight pt-12 pb-4"
+          >
+            Constructor
+          </h2>
+          <div key={classConstructor.longname} className="pb-4">
+          {classConstructor.params.map(field => (
+            <div key={field.longname} className="pb-4">
+              <h3 id={field.name} className="font-mono text-xl pt-6">
+                <a href={`#${field.name}`} className="block">
+                  <span className="font-semibold">{field.name}:</span>{" "}
+                  <Types types={field.types} />
+                </a>
+              </h3>
+              <div className="text-base">
+                <Markdown>{field.description}</Markdown>
+              </div>
+            </div>
+          ))}
+          </div>
+        </div>
+      ) : null}
       {publicClass.fields.length > 0 ? (
         <div>
           <h2


### PR DESCRIPTION
Adds support for constructor options so stuff like the following is possible when you add documentation for constructor parameters.

![image](https://user-images.githubusercontent.com/2593480/71863876-2ccde300-30f6-11ea-8818-fbe0050349b0.png)
