### PR TITLE
No longer link to the next/previous section in quickstarts

### DIFF
--- a/src/routes/quickstarts.js
+++ b/src/routes/quickstarts.js
@@ -10,8 +10,18 @@ export default function QuickstartsPage(props) {
   return (
     <ThreeColumnLayout
       routes={docsRouter.routes}
-      previousPage={docsRouter.previousPage}
-      nextPage={docsRouter.nextPage}
+      previousPage={
+        docsRouter.previousPage &&
+        router.activePage.parent === docsRouter.previousPage.parent
+          ? docsRouter.previousPage
+          : null
+      }
+      nextPage={
+        docsRouter.nextPage &&
+        router.activePage.parent === docsRouter.nextPage.parent
+          ? docsRouter.nextPage
+          : null
+      }
     >
       {props.children}
     </ThreeColumnLayout>


### PR DESCRIPTION
Currently the React testing page links to the next section which is the Vue development guide. While it is the next page, it's a little strange to go from React testing to Vue development.

This PR scopes the previous/next page of the quickstarts to routes that are within the quickstart section.