### PR TITLE
React Native Testing Library Quickstart

### DIFF
--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -126,6 +126,16 @@ const allRoutes: RouteDefinition[] = [
       },
       { label: "Ember", name: "ember" },
       { label: "Cypress", name: "cypress" },
+      {
+        label: "React Native",
+        name: "react-native",
+        routes: [
+          {
+            label: "React Native Testing Library",
+            name: "react-native-testing-library",
+          },
+        ],
+      },
     ],
   },
 ]

--- a/src/routes/quickstarts/react-native/react-native-testing-library.mdx
+++ b/src/routes/quickstarts/react-native/react-native-testing-library.mdx
@@ -136,7 +136,7 @@ const App = () => {
 
   return users.length === 0 ? (
     <SafeAreaView style={{flex: 1}}>
-      <Text testID="no-users">No users have been found!</Text>
+      <Text testID="no-users">No users!</Text>
     </SafeAreaView>
   ) : (
     <SafeAreaView style={{flex: 1}} testID="users">

--- a/src/routes/quickstarts/react-native/react-native-testing-library.mdx
+++ b/src/routes/quickstarts/react-native/react-native-testing-library.mdx
@@ -18,13 +18,9 @@ yarn add --dev miragejs
 
 ## Step 2: Setup your testing environment
 
-Out of the box, React Native does a good job to polyfill browser API's that we might need in libraries that were originally built to run on the browser. Our problem when using Mirage in a Jest testing environment is that we don't have access to some properties that the browser provides by default. To get around this issue we must update Jest's environment immediately after its setup is finished.
+Update your Jest environment:
 
-To update your Jest environment follow these steps:
-
-1. Create a setup file in the root of your project. For the purpose of this guide we'll call it `jest.setup.js`.
-
-2. Install a polyfill for XMLHttpRequest:
+1. Install a polyfill for XMLHttpRequest:
 
 ```bash
 # Using npm
@@ -34,7 +30,8 @@ npm install --save-dev xmlhttprequest
 yarn add --dev xmlhttprequest
 ```
 
-3. Patch the variable `global` in your `jest.setup.js` to add support for XMLHttpRequest, self and window.
+
+2. Create a new `jest.setup.js` file in the root of your project. We'll use this file to patch the variable `global` and add support for XMLHttpRequest, self and window.
 
 ```js
 // jest.setup.js
@@ -43,7 +40,7 @@ global.window = {};
 global.XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
 ```
 
-4. Tell Jest to load the environment that we've created by adding the [`setupFilesAfterEnv`](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array) to your Jest configuration. We must add `jest.setup.js` as an item in the list of files that Jest must execute after setting up its environment.
+3. Tell Jest to load the environment that we've created by adding the [`setupFilesAfterEnv`](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array) to your Jest configuration.
 
 > Your jest configuration can be found on your package.json or in the root of your project with the name `jest.config.js`.
 
@@ -57,6 +54,7 @@ module.exports = {
   setupFilesAfterEnv: ['./jest.setup.js'],
 };
 ```
+Here we're telling Jest to execute our `jest.setup.js` after it sets up the test environment.
 
 ## Step 3: Define your server
 
@@ -68,10 +66,9 @@ Here's a basic example:
 // src/server.js
 import { Server, Model } from "miragejs"
 
-export function makeServer({ environment = "development", trackRequests = false } = {}) {
+export function makeServer({ environment = "development" } = {}) {
   let server = new Server({
     environment,
-    trackRequests,
 
     models: {
       user: Model,
@@ -113,7 +110,7 @@ const App = () => {
   useEffect(() => {
     let fetchUsers = async () => {
       try {
-        let res = await fetch('http://localhost:3000/v1/api/users');
+        let res = await fetch('/users');
         let data = await res.json();
 
         if (!res.ok) {
@@ -131,22 +128,24 @@ const App = () => {
 
   if (serverError) {
     return (
-      <SafeAreaView style={{flex: 1}} testID="server-error">
-        <Text testID="server-error-message">{serverError}</Text>
+      <SafeAreaView style={{flex: 1}}>
+        <Text testID="server-error">{serverError}</Text>
       </SafeAreaView>
     );
   }
 
   return users.length === 0 ? (
-    <SafeAreaView style={{flex: 1}} testID="empty-users">
-      <Text>No users have been found!</Text>
+    <SafeAreaView style={{flex: 1}}>
+      <Text testID="no-users">No users have been found!</Text>
     </SafeAreaView>
   ) : (
-    <SafeAreaView style={{flex: 1}} testID="user-list">
+    <SafeAreaView style={{flex: 1}} testID="users">
       {users.map(user => {
         return (
-          <View key={user.id}>
-            <Text>{user.name}</Text>
+          <View key={user.id} testID="users">
+            <Text testID={`user-${user.id}`}>
+              {user.name}
+            </Text>
           </View>
         );
       })}
@@ -162,7 +161,7 @@ Create a new `src/__tests__/App.test.js` file, import your `makeServer` function
 ```js
 // src/__tests__/App.test.js
 import React from "react"
-import { render, waitForElement } from "@testing-library/react"
+import { render, waitForElement } from "@testing-library/react-native"
 import App from "../App"
 import { makeServer } from "../server"
 
@@ -184,23 +183,26 @@ Use your tests to seed Mirage with different data scenarios, then assert against
 > In the `test` environment, Mirage doesn't load its database `seeds`, so that the server starts out empty for each test run.
 
 ```js
-it('renders the list of users from the server', async () => {
-  // Add user data to the mirage db
-  server.create('user', {name: 'Bob'});
-  server.create('user', {name: 'Alice'});
+it("shows the users from our server", async () => {
+  server.create("user", { name: "Luke" })
+  server.create("user", { name: "Leia" })
 
-  let {getByTestId} = render(<App />);
+  const { getByTestId } = render(<App />)
+  await waitForElement(() => getByTestId("user-1"))
+  await waitForElement(() => getByTestId("user-2"))
 
-  await wait(() => expect(getByTestId('empty-users')).not.toBeEmpty());
+  expect(getByTestId("user-1")).toHaveTextContent("Luke")
+  expect(getByTestId("user-2")).toHaveTextContent("Leia")
+})
 
-  await wait(() => {
-    // Verify the number of requests handled by pretender.
-    let requests = server.pretender.handledRequests;
+it("shows a message if there are no users", async () => {
+  // Don't create any users
 
-    expect(getByTestId('user-list')).not.toBeEmpty();
-    expect(requests).toHaveLength(1);
-  });
-});
+  const { getByTestId } = render(<App />)
+  await waitForElement(() => getByTestId("no-users"))
+
+  expect(getByTestId("no-users")).toHaveTextContent("No users!")
+})
 ```
 
 ## Step 6: Alter your Mirage server to test different server states
@@ -213,30 +215,28 @@ For example, you can test an error state like this:
 // src/__tests__/App.test.js
 import { Response } from "miragejs"
 
-it('should handle server errors', async () => {
-  let message = 'Internal Server error.';
+it("handles error responses from the server", async () => {
+  // Override Mirage's route handler for /users, just for this test
+  server.get("/users", () => {
+    return new Response(
+      500,
+      {},
+      {
+        error: "The database is on vacation.",
+      }
+    )
+  })
 
-  // Set a network error response on Mirage.
-  server.get('/users', () => {
-    return new Response(500, {}, {error: message});
-  });
+  const { getByTestId } = render(<App />)
 
-  let {getByTestId, debug} = render(<App />);
+  await waitForElement(() => getByTestId("server-error"))
 
-  await wait(() => expect(getByTestId('empty-users')).not.toBeEmpty());
-
-  await wait(() => {
-    expect(getByTestId('server-error')).not.toBeEmpty();
-    expect(getByTestId('server-error-message')).toHaveTextContent(message);
-
-    // Verify the number of requests handled by pretender.
-    let requests = server.pretender.handledRequests;
-
-    expect(requests).toHaveLength(1);
-  });
+  expect(getByTestId("server-error")).toHaveTextContent(
+    "The database is on vacation."
+  )
 });
 ```
 
 Because of the way we setup Mirage using `beforeEach` and `afterEach`, each test will get a fresh Mirage server based on your main server definition. Any overrides you make within a test will be isolated to that test.
 
-To see a full working example go [here](https://github.com/eluciano11/react-native-mirage).
+To see a working example go [here](https://github.com/eluciano11/react-native-mirage).

--- a/src/routes/quickstarts/react-native/react-native-testing-library.mdx
+++ b/src/routes/quickstarts/react-native/react-native-testing-library.mdx
@@ -1,0 +1,242 @@
+# Mock Network Requests in React Native Testing Library with Mirage
+
+Use your Mirage server to test your React Native application under different server scenarios using [React Native Testing Library](https://github.com/testing-library/native-testing-library) and [Jest Native](https://github.com/testing-library/jest-native).
+
+> This is a quickstart guide should also work for people using [`react-test-renderer`](https://reactjs.org/docs/test-renderer.html) or [`react-native-testing-library`](https://github.com/callstack/react-native-testing-library).
+
+## Step 1: Install Mirage
+
+First, make sure you have Mirage installed:
+
+```bash
+# Using npm
+npm install --save-dev miragejs
+
+# Using Yarn
+yarn add --dev miragejs
+```
+
+## Step 2: Setup your testing environment
+
+Out of the box, React Native does a good job to polyfill browser API's that we might need in libraries that were originally built to run on the browser. Our problem when using Mirage in a Jest testing environment is that we don't have access to some properties that the browser provides by default. To get around this issue we must update Jest's environment immediately after its setup is finished.
+
+To update your Jest environment follow these steps:
+
+1. Create a setup file in the root of your project. For the purpose of this guide we'll call it `jest.setup.js`.
+
+2. Install a polyfill for XMLHttpRequest:
+
+```bash
+# Using npm
+npm install --save-dev xmlhttprequest
+
+# Using Yarn
+yarn add --dev xmlhttprequest
+```
+
+3. Patch the variable `global` in your `jest.setup.js` to add support for XMLHttpRequest, self and window.
+
+```js
+// jest.setup.js
+global.self = global;
+global.window = {};
+global.XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
+```
+
+4. Tell Jest to load the environment that we've created by adding the [`setupFilesAfterEnv`](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array) to your Jest configuration. We must add `jest.setup.js` as an item in the list of files that Jest must execute after setting up its environment.
+
+> Your jest configuration can be found on your package.json or in the root of your project with the name `jest.config.js`.
+
+```js
+// jest.config.js
+const jestPreset = require('@testing-library/react-native/jest-preset');
+
+module.exports = {
+  preset: '@testing-library/react-native',
+  setupFiles: [...jestPreset.setupFiles],
+  setupFilesAfterEnv: ['./jest.setup.js'],
+};
+```
+
+## Step 3: Define your server
+
+Create a new `server.js` file and define your mock server.
+
+Here's a basic example:
+
+```js
+// src/server.js
+import { Server, Model } from "miragejs"
+
+export function makeServer({ environment = "development", trackRequests = false } = {}) {
+  let server = new Server({
+    environment,
+    trackRequests,
+
+    models: {
+      user: Model,
+    },
+
+    seeds(server) {
+      server.create("user", { name: "Bob" })
+      server.create("user", { name: "Alice" })
+    },
+
+    routes() {
+      this.namespace = "api"
+
+      this.get("/users", schema => {
+        return schema.users.all()
+      })
+    },
+  })
+
+  return server
+}
+```
+
+> In a React Native App, put this file in `src/mirage/server.js` so that changes to it trigger rebuilds.
+
+## Step 4: Create a test file that uses Mirage
+
+Here's the component we'll be testing.
+
+```jsx
+// src/App.js
+import React, {useEffect, useState} from 'react';
+import {SafeAreaView, View, Text} from 'react-native';
+
+const App = () => {
+  let [users, setUsers] = useState([]);
+  let [serverError, setServerError] = useState();
+
+  useEffect(() => {
+    let fetchUsers = async () => {
+      try {
+        let res = await fetch('http://localhost:3000/v1/api/users');
+        let data = await res.json();
+
+        if (!res.ok) {
+          throw data;
+        }
+
+        setUsers(data.users);
+      } catch (error) {
+        setServerError(error.error);
+      }
+    };
+
+    fetchUsers();
+  }, []);
+
+  if (serverError) {
+    return (
+      <SafeAreaView style={{flex: 1}} testID="server-error">
+        <Text testID="server-error-message">{serverError}</Text>
+      </SafeAreaView>
+    );
+  }
+
+  return users.length === 0 ? (
+    <SafeAreaView style={{flex: 1}} testID="empty-users">
+      <Text>No users have been found!</Text>
+    </SafeAreaView>
+  ) : (
+    <SafeAreaView style={{flex: 1}} testID="user-list">
+      {users.map(user => {
+        return (
+          <View key={user.id}>
+            <Text>{user.name}</Text>
+          </View>
+        );
+      })}
+    </SafeAreaView>
+  );
+};
+
+export default App;
+```
+
+Create a new `src/__tests__/App.test.js` file, import your `makeServer` function, and start and shutdown Mirage using `beforeEach` and `afterEach`, making sure to pass the `test` environment to Mirage:
+
+```js
+// src/__tests__/App.test.js
+import React from "react"
+import { render, waitForElement } from "@testing-library/react"
+import App from "../App"
+import { makeServer } from "../server"
+
+let server
+
+beforeEach(() => {
+  server = makeServer({ environment: "test" })
+})
+
+afterEach(() => {
+  server.shutdown()
+})
+```
+
+## Step 5: Write tests using your Mirage server
+
+Use your tests to seed Mirage with different data scenarios, then assert against the state of your UI.
+
+> In the `test` environment, Mirage doesn't load its database `seeds`, so that the server starts out empty for each test run.
+
+```js
+it('renders the list of users from the server', async () => {
+  // Add user data to the mirage db
+  server.create('user', {name: 'Bob'});
+  server.create('user', {name: 'Alice'});
+
+  let {getByTestId} = render(<App />);
+
+  await wait(() => expect(getByTestId('empty-users')).not.toBeEmpty());
+
+  await wait(() => {
+    // Verify the number of requests handled by pretender.
+    let requests = server.pretender.handledRequests;
+
+    expect(getByTestId('user-list')).not.toBeEmpty();
+    expect(requests).toHaveLength(1);
+  });
+});
+```
+
+## Step 6: Alter your Mirage server to test different server states
+
+In addition to different data scenarios, you can use your tests to reconfigure your Mirage server to test new situations.
+
+For example, you can test an error state like this:
+
+```js
+// src/__tests__/App.test.js
+import { Response } from "miragejs"
+
+it('should handle server errors', async () => {
+  let message = 'Internal Server error.';
+
+  // Set a network error response on Mirage.
+  server.get('/users', () => {
+    return new Response(500, {}, {error: message});
+  });
+
+  let {getByTestId, debug} = render(<App />);
+
+  await wait(() => expect(getByTestId('empty-users')).not.toBeEmpty());
+
+  await wait(() => {
+    expect(getByTestId('server-error')).not.toBeEmpty();
+    expect(getByTestId('server-error-message')).toHaveTextContent(message);
+
+    // Verify the number of requests handled by pretender.
+    let requests = server.pretender.handledRequests;
+
+    expect(requests).toHaveLength(1);
+  });
+});
+```
+
+Because of the way we setup Mirage using `beforeEach` and `afterEach`, each test will get a fresh Mirage server based on your main server definition. Any overrides you make within a test will be isolated to that test.
+
+To see a full working example go [here](https://github.com/eluciano11/react-native-mirage).

--- a/src/routes/quickstarts/react-native/react-native-testing-library.mdx
+++ b/src/routes/quickstarts/react-native/react-native-testing-library.mdx
@@ -110,7 +110,7 @@ const App = () => {
   useEffect(() => {
     let fetchUsers = async () => {
       try {
-        let res = await fetch('/users');
+        let res = await fetch('/api/users');
         let data = await res.json();
 
         if (!res.ok) {


### PR DESCRIPTION
This PR adds the quickstart guide for using Mirage in React Native tests. The guide will probably work for people that are using different testing libraries such as `react-test-renderer` and `testing-library/react-native`. I decided to use React Native Testing Library in this quickstart because its the library that I'm currently using. The reason that I think the guide should work for different libraries is because changes that have to be made are to Jest environment itself and not to the testing libraries. 

That being said, I won't merge this PR yet because there's still a small issue with Pretender that needs to be fixed. There's ways to get around the Pretender issue but I think users will have a better experience if Pretender is fixed first. Here's some info about the Pretender issue: https://github.com/miragejs/miragejs/issues/104

Please let me know if you'd like me to change anything in the PR.