### PR TITLE
Update Cypress typo on assertions page

### DIFF
--- a/src/routes/docs/testing/assertions.mdx
+++ b/src/routes/docs/testing/assertions.mdx
@@ -10,7 +10,7 @@ To address this class of issues, you can assert against the state of your Mirage
 
 The simplest way to assert that your app is sending over the correct data to your backend is to assert against Mirage's database. If the correct data makes it there, you'll have confidence not only that the JSON payloads from your JavaScript app are correct, but that your Mirage route handlers are behaving as you expect.
 
-Here's an example using Cyprus:
+Here's an example using Cypress:
 
 ```js
 it("can change the movie title", function() {


### PR DESCRIPTION
Small PR, I know, but it might help somebody else that tries to Google "Cypress" based on the assertions page (which happened in my case, and lead to this!) 🤷‍♂️