### PR TITLE
Escape hatch with MIRAGE_ENABLED env variable

### DIFF
--- a/src/routes/quickstarts/vue/exclude-from-production.mdx
+++ b/src/routes/quickstarts/vue/exclude-from-production.mdx
@@ -24,7 +24,10 @@ Next, add the following to your `vue.config.js`:
 // vue.config.js
 module.exports = {
   chainWebpack: config => {
-    if (process.env.NODE_ENV === "production") {
+    if (
+      process.env.NODE_ENV === "production" &&
+      process.env.MIRAGE_ENABLED !== "true"
+    ) {
       config.module
         .rule("exclude-mirage")
         .test(/node_modules\/miragejs\//)


### PR DESCRIPTION
This makes it a little easier to include Mirage in production builds