### PR TITLE
Adds quickstart guide for Svelte

### DIFF
--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -125,6 +125,7 @@ const allRoutes: RouteDefinition[] = [
         ],
       },
       { label: "Ember", name: "ember" },
+      { label: "Svelte", name: "svelte" },
       { label: "Cypress", name: "cypress" },
     ],
   },

--- a/src/routes/quickstarts/svelte.mdx
+++ b/src/routes/quickstarts/svelte.mdx
@@ -4,7 +4,7 @@ Mock your Svelte app's networking code so you can develop your Svelte app withou
 
 > This is a quickstart guide for people familiar with Mirage. If you're brand new to Mirage, take a look at the [Overview](/docs/getting-started/overview).
 
-## Step 1: Create your Svelte app
+## Step 1: Create your app
 
 ```bash
 npx degit sveltejs/template svelte-mirage

--- a/src/routes/quickstarts/svelte.mdx
+++ b/src/routes/quickstarts/svelte.mdx
@@ -64,11 +64,11 @@ import * as sapper from '@sapper/app';
 import { makeServer } from "./mirage";
 
 if (process.env.NODE_ENV === "development") {
-	makeServer()
+  makeServer()
 }
 
 sapper.start({
-	target: document.querySelector('#sapper')
+  target: document.querySelector('#sapper')
 });
 ```
 
@@ -77,7 +77,7 @@ Now, whenever your application makes a network request in development, Mirage wi
 For example, given the server definition above, the following component would fetch the users `Bob` and `Alice` that we defined in `seeds`:
 
 ```html
-// src/routes/users.svelte
+<!-- src/routes/users.svelte -->
 <script>
   import { onMount } from "svelte";
 
@@ -91,9 +91,9 @@ For example, given the server definition above, the following component would fe
 
 <div>
   {#if users}
-	{#each users as user}
-	  <li>{user.name}</li>
-	{/each}
+    {#each users as user}
+      <li>{user.name}</li>
+    {/each}
   {:else}
     <p>loading.....</p>
   {/if}

--- a/src/routes/quickstarts/svelte.mdx
+++ b/src/routes/quickstarts/svelte.mdx
@@ -40,7 +40,6 @@ Replace the content of `src/App.js` with:
 
   let users
 
-
   onMount(async () => {
     const response = await fetch("/api/users")
     const data = await response.json()

--- a/src/routes/quickstarts/svelte.mdx
+++ b/src/routes/quickstarts/svelte.mdx
@@ -48,10 +48,11 @@ Replace the content of `src/App.js` with:
 </script>
 
 <main>
-  {#if users} {#each users as user}
-    <li>{user.name}</li>
-  {/each} {:else}
-
+  {#if users}
+    {#each users as user}
+      <li>{user.name}</li>
+    {/each}
+  {:else}
     <p>loading.....</p>
   {/if}
 </main>

--- a/src/routes/quickstarts/svelte.mdx
+++ b/src/routes/quickstarts/svelte.mdx
@@ -4,9 +4,14 @@ Mock your Svelte app's networking code so you can develop your Svelte app withou
 
 > This is a quickstart guide for people familiar with Mirage. If you're brand new to Mirage, take a look at the [Overview](/docs/getting-started/overview).
 
-## Step 1: Install Mirage
+## Step 1: Create your Svelte app
 
-First, make sure you have Mirage installed:
+```bash
+npx degit sveltejs/template svelte-mirage
+cd svelte-mirage
+```
+
+## Step 2: Install Mirage
 
 ```bash
 # Using npm
@@ -16,88 +21,45 @@ npm install --save-dev miragejs
 yarn add --dev miragejs
 ```
 
-## Step 2: Define your server
+## Step 3: Update your bootstrap file
 
-Create a new `mirage.js` file and define your mock server.
+Replace the content of `src/App.js` with:
 
-Here's a basic example:
+```html
+<script>
+  import { onMount } from "svelte"
+  import { Server } from "miragejs"
 
-```js
-// src/routes/mirage.js
-import { Server, Model } from "miragejs"
-
-export function makeServer({ environment = "development" } = {}) {
-  let server = new Server({
-    environment,
-
-    models: {
-      user: Model,
-    },
-
-    seeds(server) {
-      server.create("user", { name: "Bob" })
-      server.create("user", { name: "Alice" })
-    },
-
+  new Server({
     routes() {
-      this.passthrough("/**")
-
-      this.namespace = "/api"
-
-      this.get("/users", schema => {
-        return schema.users.all()
-      })
+      this.get("/api/users", () => ({
+        users: [{ name: "Sam" }, { name: "Ryan" }],
+      }))
     },
   })
 
-  return server
-}
-```
+  let users
 
-## Step 3: Start your server in development
-
-Open your Svelte app's bootstrap file (`src/routes/client.js` in a Sapper App), import your `makeServer` function, and call it in the development environment:
-
-```js{3,5-7}
-// src/routes/client.js
-import * as sapper from '@sapper/app';
-import { makeServer } from "./mirage";
-
-if (process.env.NODE_ENV === "development") {
-	makeServer()
-}
-
-sapper.start({
-	target: document.querySelector('#sapper')
-});
-```
-
-Now, whenever your application makes a network request in development, Mirage will intercept that request and respond with the data from your server definition.
-
-For example, given the server definition above, the following component would fetch the users `Bob` and `Alice` that we defined in `seeds`:
-
-```html
-// src/routes/users.svelte
-<script>
-  import { onMount } from "svelte";
-
-  let users;
   onMount(async () => {
-    const response = await fetch("/api/users");
-	const data = await response.json();
-    users = data.users;
-  });
+    const response = await fetch("/api/users")
+    const data = await response.json()
+    users = data.users
+  })
 </script>
 
-<div>
-  {#if users}
-	{#each users as user}
-	  <li>{user.name}</li>
-	{/each}
-  {:else}
+<main>
+  {#if users} {#each users as user}
+    <li>{user.name}</li>
+  {/each} {:else}
     <p>loading.....</p>
   {/if}
-</div>
+</main>
+```
+
+## Step 4: Start your development server
+
+```bash
+npm run dev
 ```
 
 You can now continue to develop your Svelte app, mocking out your backend API endpoints with Mirage as you go.

--- a/src/routes/quickstarts/svelte.mdx
+++ b/src/routes/quickstarts/svelte.mdx
@@ -1,0 +1,103 @@
+# Setup a Svelte App with Mirage for Development
+
+Mock your Svelte app's networking code so you can develop your Svelte app without any backend services.
+
+> This is a quickstart guide for people familiar with Mirage. If you're brand new to Mirage, take a look at the [Overview](/docs/getting-started/overview).
+
+## Step 1: Install Mirage
+
+First, make sure you have Mirage installed:
+
+```bash
+# Using npm
+npm install --save-dev miragejs
+
+# Using Yarn
+yarn add --dev miragejs
+```
+
+## Step 2: Define your server
+
+Create a new `mirage.js` file and define your mock server.
+
+Here's a basic example:
+
+```js
+// src/routes/mirage.js
+import { Server, Model } from "miragejs"
+
+export function makeServer({ environment = "development" } = {}) {
+  let server = new Server({
+    environment,
+
+    models: {
+      user: Model,
+    },
+
+    seeds(server) {
+      server.create("user", { name: "Bob" })
+      server.create("user", { name: "Alice" })
+    },
+
+    routes() {
+      this.passthrough("/**")
+
+      this.namespace = "/api"
+
+      this.get("/users", schema => {
+        return schema.users.all()
+      })
+    },
+  })
+
+  return server
+}
+```
+
+## Step 3: Start your server in development
+
+Open your Svelte app's bootstrap file (`src/routes/client.js` in a Sapper App), import your `makeServer` function, and call it in the development environment:
+
+```js{3,5-7}
+// src/routes/client.js
+import * as sapper from '@sapper/app';
+import { makeServer } from "./mirage";
+
+if (process.env.NODE_ENV === "development") {
+	makeServer()
+}
+
+sapper.start({
+	target: document.querySelector('#sapper')
+});
+```
+
+Now, whenever your application makes a network request in development, Mirage will intercept that request and respond with the data from your server definition.
+
+For example, given the server definition above, the following component would fetch the users `Bob` and `Alice` that we defined in `seeds`:
+
+```html
+// src/routes/users.svelte
+<script>
+  import { onMount } from "svelte";
+
+  let users;
+  onMount(async () => {
+    const response = await fetch("/api/users");
+	const data = await response.json();
+    users = data.users;
+  });
+</script>
+
+<div>
+  {#if users}
+	{#each users as user}
+	  <li>{user.name}</li>
+	{/each}
+  {:else}
+    <p>loading.....</p>
+  {/if}
+</div>
+```
+
+You can now continue to develop your Svelte app, mocking out your backend API endpoints with Mirage as you go.


### PR DESCRIPTION
## Two things

1. Syntax highlighting in `Step 2` seems off due to the `passthrough` wildcard
2. Let me know if menu order needs to change

## Test-run 
I would appreciate a test-run:

```bash
npx degit sveltejs/template my-svelte-project
cd my-svelte-project
yarn install
yarn dev
```

Then just follow the quickstart