### PR TITLE
Fix failing test in quickstarts page

### DIFF
--- a/cypress/integration/quickstarts.spec.js
+++ b/cypress/integration/quickstarts.spec.js
@@ -1,7 +1,7 @@
 describe("Quickstarts", () => {
-  it("it renders the react quickstart", () => {
-    cy.visit("/quickstarts/react/development")
-    cy.get("h1").contains("Setup a React App with Mirage for Development")
+  it("it renders the react component quickstart", () => {
+    cy.visit("/quickstarts/react/develop-a-component")
+    cy.get("h1").contains("Develop a React Component with Mirage")
     cy.screenshot("react quickstart")
   })
 })


### PR DESCRIPTION
Apparently the contents of the page have changed massively without the test being updated.

I can add other basic `h1` specs like this one for the other pages if desired, but I'd suggest to merge this one asap such that the other open pull request get a green check mark (given they don't add failing tests themself and rebase to master after this merge).

Note: I did not run the test suite locally because I'm on windows currently. So it is possible that the test will still fail, but I'm looking for it and will fix this pr again in that case.