### PR TITLE
Add missing links to serializer api docs in post/put shorthands section

### DIFF
--- a/src/routes/docs/main-concepts/shorthands.mdx
+++ b/src/routes/docs/main-concepts/shorthands.mdx
@@ -109,7 +109,7 @@ this.post("/contacts", function(schema, request) {
 })
 ```
 
-For this POST shorthand to work, Mirage needs to know the format of the JSON payload your app sends along with the request, so that it can insert the appropriate data into the database. See the note on normalize in the Serializer docs for more information.
+For this POST shorthand to work, Mirage needs to know the format of the JSON payload your app sends along with the request, so that it can insert the appropriate data into the database. See [the note on normalize](/api/classes/serializer/#normalize) in the Serializer docs for more information.
 
 ## PATCH/PUT Shorthands
 
@@ -129,7 +129,7 @@ this.patch("/contacts/:id", function(schema, request) {
 })
 ```
 
-For this PATCH shorthand to work, Mirage needs to know the format of the JSON payload your app sends along with the request, so that it can insert the appropriate data into the database. See the note on normalize in the Serializer docs for more information.
+For this PATCH shorthand to work, Mirage needs to know the format of the JSON payload your app sends along with the request, so that it can insert the appropriate data into the database. See [the note on normalize](/api/classes/serializer/#normalize) in the Serializer docs for more information.
 
 ## DELETE Shorthands
 


### PR DESCRIPTION
I failed and cannot reopen the  other pull request so I added this new one.