### PR TITLE
Fixes a bug with the FadeBetween component

### DIFF
--- a/src/components/signup-form.js
+++ b/src/components/signup-form.js
@@ -334,9 +334,12 @@ function FadeBetween({ state, children }) {
 
 function State({ cb, animatedOpacity, children }) {
   const [ref, bounds] = useMeasure({ polyfill: ResizeObserver })
-  if (bounds.height > 0) {
-    cb(bounds.height)
-  }
+
+  useEffect(() => {
+    if (bounds.height > 0) {
+      cb(bounds.height)
+    }
+  })
 
   return (
     <animated.div


### PR DESCRIPTION
I started seeing this error

> index.js:2177 Warning: Cannot update a component (`FadeBetween`) while rendering a different component (`State`).

The cause was FadeBetween setting state as it rendered its children. Putting the callback where the children report back their height in a useEffect fixed it.