### PR TITLE
Add workaround for unhandled exceptions raised from data urls

### DIFF
--- a/src/routes/docs/getting-started/overview.mdx
+++ b/src/routes/docs/getting-started/overview.mdx
@@ -598,6 +598,27 @@ new Server({
 
 and you can fully develop and test the feature. In this way you can build up your server definition piece by piece - adding some solid acceptance tests for each state of your server as you go.
 
+If your're using data urls, Mirage will still raise an unhandleled exception even you're using `this.passthrough()`.  To workaround this, you can benefit from the pretender instance that resides on the server.
+
+```js
+new Server({
+  routes() {
+    // Passthrough data urls
+    this.pretender.unhandledRequest = (verb, path, request) => {
+      if (request.url.indexOf("data:") === 0) {
+        request.passthrough();
+      }
+     };
+     
+    // Mock this route and Mirage will intercept it
+    this.get("/movies")
+
+    // All other API requests will still pass through
+    this.passthrough()
+  },
+})
+
+
 ---
 
 That should be enough to get you started!

--- a/src/routes/docs/getting-started/overview.mdx
+++ b/src/routes/docs/getting-started/overview.mdx
@@ -617,7 +617,7 @@ new Server({
     this.passthrough()
   },
 })
-
+```
 
 ---
 


### PR DESCRIPTION
I've faced this problem while using Mirage with Ionic (which uses data urls to display SVG icons).  I tried using passthrough to ignore data urls, but it did not work.

This worked for me though, and I figured I might as well document it so others don't face the issue.

![exception](https://user-images.githubusercontent.com/1207863/79671544-89e83300-81d3-11ea-9964-497769df7ab1.png)
