### PR TITLE
Deal with time between effect cleanup and handler attachment

### DIFF
--- a/src/components/code-editor.js
+++ b/src/components/code-editor.js
@@ -23,10 +23,11 @@ export default function CodeEditor({
 }) {
   let editorDivRef = React.useRef()
   let editorRef = React.useRef()
+  let handlerRef = React.useRef()
+
+  handlerRef.current = onChange
 
   React.useEffect(() => {
-    let handler = (cm) => onChange(cm.getValue())
-
     // Load CodeMirror + its plugins using dynamic import, since they
     // only work in the browser.
     const f = async () => {
@@ -38,6 +39,10 @@ export default function CodeEditor({
           value,
           mode: "javascript",
         })
+
+        editorRef.current.on("change", (cm) => {
+          handlerRef.current(cm.getValue())
+        })
       }
 
       if (dataTestId) {
@@ -47,17 +52,10 @@ export default function CodeEditor({
       }
 
       editorRef.current.setOption("extraKeys", extraKeys)
-      editorRef.current.on("change", handler)
     }
 
     f()
-
-    return () => {
-      if (editorRef.current) {
-        editorRef.current.off("change", handler)
-      }
-    }
-  }, [onChange, value, dataTestId])
+  }, [value, dataTestId, extraKeys])
 
   return (
     <>

--- a/src/routes/repl.js
+++ b/src/routes/repl.js
@@ -362,7 +362,7 @@ export default function () {
               </div>
             </div>
             <div className="overflow-y-auto bg-gray-100 h-1/2">
-              <div className="bg-white py-2 px-4 md:px-6 shadow flex">
+              <div className="flex px-4 py-2 bg-white shadow md:px-6">
                 <button
                   onClick={() => setActiveResponseTab("JSON")}
                   className={`mr-4 text-sm font-medium focus:outline-none
@@ -435,7 +435,7 @@ export default function () {
                 ) : inspectorState.value === "failedRequest" ? (
                   <div>
                     <p>The REPL threw an error.</p>
-                    <p className="pt-2 text-red-600 font-medium">
+                    <p className="pt-2 font-medium text-red-600">
                       {inspectorState.context.errorHandlingRequest}
                     </p>
                   </div>


### PR DESCRIPTION
Provide a single function to code mirror that points to a ref. We'll be responsible for updating the ref with the right onChange handler.

This prevents a potential CI bug we were there was a small point in time when no event handler was attached.
