### PR TITLE
Let iframe control loading state

### DIFF
--- a/src/routes/repl.js
+++ b/src/routes/repl.js
@@ -32,13 +32,13 @@ const inspectorMachine = Machine(
       },
       error: {
         on: {
-          CONFIG_CHANGE: "loading",
+          RESTART: "loading",
         },
       },
       ready: {
         entry: ["clearError", "updateDatabase"],
         on: {
-          CONFIG_CHANGE: "loading",
+          RESTART: "loading",
         },
         initial: "idle",
         states: {
@@ -128,8 +128,6 @@ export default function () {
   let configIsTooLargeForURL = localConfig !== null
 
   function handleConfigInputChange(newConfigInput) {
-    send("CONFIG_CHANGE")
-
     if (btoa(newConfigInput).length < 2000) {
       setQueryParamConfig(newConfigInput)
       setLocalConfig(null)
@@ -141,7 +139,9 @@ export default function () {
 
   function handleMessage({ data }) {
     if (data.fromSandbox) {
-      if (data.type === "mirage:db") {
+      if (data.type === "mirage:initializing") {
+        send("RESTART")
+      } else if (data.type === "mirage:db") {
         send("SUCCESS", { db: data.message })
       } else if (data.type === "mirage:response") {
         send("RESPONSE", {

--- a/src/tutorial-assets/snippets/iframe-shell.md
+++ b/src/tutorial-assets/snippets/iframe-shell.md
@@ -130,6 +130,8 @@
       //   )
       // }
 
+      sendMessage("mirage:initializing")
+
       runtime
         .import("./index.js")
         .then(() => {


### PR DESCRIPTION
We're currently transitioning the state machine to loading every time the config changes, but this has a race condition where you transition to loading, and before you render the new srcDoc the previous srcDoc errors. This transitions from loading to error, before your new config is ever executed.

Typing really quickly in the editor reproduces this. I'm not sure how to reproduce with cypress.

This made me realize that the state machine isn't really loading until the new config is sent to the iframe. This PR makes it so the iframe puts the state machine back into loading once it starts executing JS.

There might be a new state that happens when we receive a config change, but before we've rendered the new srcDoc. Maybe something like...

```
PENDING_CONFIG_UPDATE -> LOADING -> [READY|ERROR]
```

However, I'm thinking we should hold off on adding new states until we need them for some reason.

Also, unrelated but something I didn't think about... since the iframe has a bunch of plunker/async stuff, is there any chance of an older render posting a message that we no longer care about? I'm guessing the answer is no since we haven't seen it happen, but I'm wondering if we should have a mechanism for ignoring messages that are no longer relevant. 