### PR TITLE
Tell Netlify builds to ignore dependabot

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  ignore = "git log -1 --pretty=%B | grep dependabot"


### PR DESCRIPTION
Reference: https://www.netlify.com/blog/2020/04/27/ignore-unnecessary-builds-to-optimize-your-build-times/