### PR TITLE
Add temporary fix for importing GraphQL in REPL

### DIFF
--- a/src/tutorial-assets/snippets/iframe-shell.md
+++ b/src/tutorial-assets/snippets/iframe-shell.md
@@ -4,6 +4,10 @@
   <head></head>
   <body>
     <div id="demo"></div>
+    <script>
+      // Fix for GraphQL (see https://github.com/graphql/graphql-js/issues/2676)
+      window.process = window.process || { env: "production" }
+    </script>
     <script src="https://unpkg.com/@plnkr/runtime@1.0.0-pre.9/dist/runtime.js"></script>
     <script>
       // current revision provided by parent component


### PR DESCRIPTION
This PR adds a temporary fix for an issue when importing GraphQL in the REPL. See https://github.com/graphql/graphql-js/issues/2676 for more details on the root of the problem. According to the open GraphQL JS issue, we should be able to remove this fix after their next major release. Relates to #264.