### PR TITLE
Escape backticks in REPL input

### DIFF
--- a/src/routes/repl.js
+++ b/src/routes/repl.js
@@ -223,7 +223,6 @@ export default function ({ location, navigate }) {
   let lineForApp = shellLines.findIndex((line) => line.match("App.js"))
   shellLines.splice(lineForApp + 1, 0, ...configInput.split("\n"))
   let srcDoc = shellLines.join("\n")
-
   const [debouncedSrcDoc] = useDebounce(srcDoc, 225)
 
   const CreateSandbox = `

--- a/src/routes/repl.js
+++ b/src/routes/repl.js
@@ -10,6 +10,7 @@ import { useMutation } from "urql"
 import { DialogOverlay, DialogContent } from "@reach/dialog"
 import queryString from "query-string"
 import { useDebounce } from "use-debounce"
+import { escapeBackticks } from "../utils"
 
 const inspectorMachine = Machine(
   {
@@ -151,7 +152,7 @@ export default function ({ location, navigate }) {
 
   function handleConfigInputChange(newConfigInput) {
     send("CONFIG_CHANGE")
-    setConfigInput(newConfigInput)
+    setConfigInput(escapeBackticks(newConfigInput))
   }
 
   function handleMessage({ data }) {
@@ -222,6 +223,7 @@ export default function ({ location, navigate }) {
   let lineForApp = shellLines.findIndex((line) => line.match("App.js"))
   shellLines.splice(lineForApp + 1, 0, ...configInput.split("\n"))
   let srcDoc = shellLines.join("\n")
+
   const [debouncedSrcDoc] = useDebounce(srcDoc, 225)
 
   const CreateSandbox = `

--- a/src/tests/utils/utils.test.js
+++ b/src/tests/utils/utils.test.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-template-curly-in-string */
+
+import { escapeBackticks } from "../../utils"
+
+describe("Utils", () => {
+  describe("escapeBackticks", () => {
+    it("escapes backticks for use when nesting template literals", () => {
+      const str = "Hello, `${name}`"
+
+      expect(`${escapeBackticks(str)}`).toBe("Hello, \\`${name}\\`")
+    })
+  })
+})

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,7 @@
+export function escapeBackticks(str) {
+  return str.replace(/`/g, "\\`")
+}
+
 export function urlsMatch(url1, url2) {
   return url1.replace(/\/+$/, "") === url2.replace(/\/+$/, "")
 }


### PR DESCRIPTION
This PR fixes an issue where template strings weren't being escaped when found in the REPL input. Relates to #264.