### PR TITLE
Make importing Mirage GraphQL work in the REPL

### DIFF
--- a/src/tutorial-assets/snippets/iframe-shell.md
+++ b/src/tutorial-assets/snippets/iframe-shell.md
@@ -54,6 +54,23 @@
         },
       }
       const PlnkrRuntime = window.PlnkrRuntime
+      const plnkrInstantiate = PlnkrRuntime.Runtime.prototype[
+        PlnkrRuntime.Runtime.instantiate
+      ]
+
+      // Monkey patch module loading for Mirage GraphQL
+      PlnkrRuntime.Runtime.prototype[PlnkrRuntime.Runtime.instantiate] =
+        function(key, processAnonRegister) {
+          return plnkrInstantiate.call(
+            this,
+            key.replace(
+              /https:\/\/dev\.jspm\.io\/@miragejs\/graphql(.*)/,
+              'https://jspm.dev/@miragejs/graphql$1'
+            ),
+            processAnonRegister
+          )
+        }
+
       const runtime = new PlnkrRuntime.Runtime({ host })
 
       function sendMessage(type, message) {


### PR DESCRIPTION
This PR introduces a hack to get importing Mirage GraphQL working in the REPL. For reasons unknown to me, Mirage GraphQL won't load in the REPL. It definitely has something to do with the Mirage GraphQL distribution, the REPL's dependence on Plnkr and Plnkr's usage of jspm.io.

Relates to #264.

**Note:** This shouldn't affect other imported dependencies at all.