### PR TITLE
Allow template strings in REPL request body for multi-line strings

### DIFF
--- a/src/components/inspector/request.js
+++ b/src/components/inspector/request.js
@@ -15,6 +15,10 @@ export default function ({
   let [urlIsValid, setUrlIsValid] = useState(true)
   let [requestBodyIsValid, setRequestBodyIsValid] = useState(true)
 
+  function cleanJSON(json) {
+    return json.replace(/`/g, "'").replace(/\n/g, "")
+  }
+
   function handleRequestBodyChange(e) {
     setRequestBodyIsValid(true)
     setRequestBody(e)
@@ -38,7 +42,7 @@ export default function ({
   function hasJsonStructure(str) {
     if (typeof str !== "string" || str === "") return true
     try {
-      const result = JSON5.parse(str)
+      const result = JSON5.parse(cleanJSON(str))
       const type = Object.prototype.toString.call(result)
       return type === "[object Object]" || type === "[object Array]"
     } catch (error) {


### PR DESCRIPTION
This PR allows template strings in the request body (for multi-line text only). It does so by replacing back ticks with single quotes and stripping new line characters when validating JSON in request bodies. The result works with the JSON5 library we're using to parse the request body. Closes #962 and closes #264.

This should enable https://miragejs.com/repl/v1/370.