### PR TITLE
Add link to example REPL on GraphQL guides page

### DIFF
--- a/src/routes/docs/advanced/graphql.mdx
+++ b/src/routes/docs/advanced/graphql.mdx
@@ -8,6 +8,8 @@ To get started, import the `createGraphQLHandler` function from Mirage GraphQL a
 
 In the following example, you don't need to supply your own resolvers for any of the queries or mutations. Additionally, you don't need to create any Mirage models. Mirage GraphQL will create models for you based on your GraphQL schema.
 
+[Try the example out in the REPL](https://miragejs.com/repl/v1/370)!
+
 ```js
 import { createServer } from "miragejs"
 import { createGraphQLHandler } from "@miragejs/graphql"
@@ -96,6 +98,6 @@ There are a lot more things Mirage GraphQL can do. For example, you can
 
 and more.
 
-Mirage GraphQL is v0.1.0, but extracted from years of work on the `ember-cli-mirage-graphq` library.
+Mirage GraphQL is v0.1.x, but extracted from years of work on the `ember-cli-mirage-graphq` library.
 
 To learn more, check out the README of [Mirage GraphQL](https://github.com/miragejs/graphql). Also check out the intergration tests for more in-depth examples of options, queries and mutations.

--- a/src/routes/docs/advanced/graphql.mdx
+++ b/src/routes/docs/advanced/graphql.mdx
@@ -8,7 +8,7 @@ To get started, import the `createGraphQLHandler` function from Mirage GraphQL a
 
 In the following example, you don't need to supply your own resolvers for any of the queries or mutations. Additionally, you don't need to create any Mirage models. Mirage GraphQL will create models for you based on your GraphQL schema.
 
-[Try the example out in the REPL](https://miragejs.com/repl/v1/370)!
+<a href="https://miragejs.com/repl/v1/370" target="_blank">Try this example in the REPL</a>!
 
 ```js
 import { createServer } from "miragejs"
@@ -98,6 +98,6 @@ There are a lot more things Mirage GraphQL can do. For example, you can
 
 and more.
 
-Mirage GraphQL is v0.1.x, but extracted from years of work on the `ember-cli-mirage-graphq` library.
+Mirage GraphQL is v0.1.*x*, but extracted from years of work on the `ember-cli-mirage-graphq` library.
 
 To learn more, check out the README of [Mirage GraphQL](https://github.com/miragejs/graphql). Also check out the intergration tests for more in-depth examples of options, queries and mutations.


### PR DESCRIPTION
This PR adds a link to the shared REPL with the GraphQL example from the guides. It also updates one small bit about the Mirage GraphQL version.