### PR TITLE
Add link to graphql-mocks for graphql docs

### DIFF
--- a/src/routes/docs/advanced/graphql.mdx
+++ b/src/routes/docs/advanced/graphql.mdx
@@ -109,5 +109,6 @@ As an unofficial community-based alternative to mocking with Mirage and GraphQL 
 Consider using `graphql-mocks` with Mirage for:
 * Composable middlewares for managing and creating different scenarios and states
 * Resolver and resolver map abstractions for extending query resolutions
-* Agnostic network and support for Node
+* Mocking in Node environments
+* Mocking flexibly with different networks abstractions (Mock Service Worker, Nock, etc.)
 * Full typescript support and type compatability with `graphql` types

--- a/src/routes/docs/advanced/graphql.mdx
+++ b/src/routes/docs/advanced/graphql.mdx
@@ -101,3 +101,13 @@ and more.
 Mirage GraphQL is v0.1.*x*, but extracted from years of work on the `ember-cli-mirage-graphq` library.
 
 To learn more, check out the README of [Mirage GraphQL](https://github.com/miragejs/graphql). Also check out the intergration tests for more in-depth examples of options, queries and mutations.
+
+## Mirage & `graphql-mocks`
+
+As an unofficial community-based alternative to mocking with Mirage and GraphQL check out [`graphql-mocks`](https://www.graphql-mocks.com) and its [Mirage middleware](https://www.graphql-mocks.com/docs/guides/mirage-js).
+
+Consider using `graphql-mocks` with Mirage for:
+* Composable middlewares for managing and creating different scenarios and states
+* Resolver and resolver map abstractions for extending query resolutions
+* Agnostic network and support for Node
+* Full typescript support and type compatability with `graphql` types

--- a/src/routes/docs/advanced/graphql.mdx
+++ b/src/routes/docs/advanced/graphql.mdx
@@ -98,7 +98,7 @@ There are a lot more things Mirage GraphQL can do. For example, you can
 
 and more.
 
-Mirage GraphQL is v0.1.*x*, but extracted from years of work on the `ember-cli-mirage-graphq` library.
+Mirage GraphQL is v0.1.*x*, but extracted from years of work on the `ember-cli-mirage-graphql` library.
 
 To learn more, check out the README of [Mirage GraphQL](https://github.com/miragejs/graphql). Also check out the intergration tests for more in-depth examples of options, queries and mutations.
 


### PR DESCRIPTION
@samselikoff @jneurock 
As discussed on discord, this pull request adds a link in the graphql docs to `graphql-mocks` and an alternative Mirage solution for mocking GraphQL APIs.

Just wanted to get something "on the page", happy to make any edits.