### PR TITLE
Remove graphql-request from GraphQL example and update REPL link

### DIFF
--- a/src/routes/docs/advanced/graphql.mdx
+++ b/src/routes/docs/advanced/graphql.mdx
@@ -8,12 +8,11 @@ To get started, import the `createGraphQLHandler` function from Mirage GraphQL a
 
 In the following example, you don't need to supply your own resolvers for any of the queries or mutations. Additionally, you don't need to create any Mirage models. Mirage GraphQL will create models for you based on your GraphQL schema.
 
-<a href="https://miragejs.com/repl/v2/e217131cb5" target="_blank">Try this example in the REPL</a>!
+<a href="https://miragejs.com/repl/v2/48fda9b330" target="_blank">Try this example in the REPL</a>!
 
 ```js
 import { createServer } from "miragejs"
 import { createGraphQLHandler } from "@miragejs/graphql"
-import { request } from "graphql-request"
 
 const graphQLSchema = `
   input MovieInput {


### PR DESCRIPTION
The GraphQL page in the docs includes a code sample that needlessly imports `graphql-request`. This PR removes the unused import and updates the link to the REPL example since that too included the import.