### PR TITLE
Replace links to faker.js

### DIFF
--- a/src/routes/docs/main-concepts/factories.mdx
+++ b/src/routes/docs/main-concepts/factories.mdx
@@ -205,7 +205,7 @@ createServer({
 })
 ```
 
-Here we've installed the [Faker.js](https://github.com/marak/Faker.js/) library to help us generate random dates.
+Here we've installed the [Faker.js](https://fakerjs.dev/) library to help us generate random dates.
 
 Now if we create 5 movies in our development seeds
 

--- a/src/routes/tutorial/part-8.mdx
+++ b/src/routes/tutorial/part-8.mdx
@@ -81,7 +81,7 @@ Now each reminder has its own unique text:
 
 ![Dyanamic attr](../../assets/images/tutorial/part-8-dynamic-attr.png)
 
-Libraries like [faker.js](https://github.com/marak/Faker.js/) also work well in function properties to create even higher fidelity data.
+Libraries like [faker.js](https://fakerjs.dev/) also work well in function properties to create even higher fidelity data.
 
 Combined with `server.createList`, we can now easily create many Reminders using our Factory definition:
 


### PR DESCRIPTION
Now that there's a new official faker.js project, I think it would be good to move the links so that folks aren't sent to the old, broken one.

cc @samselikoff, I know you were bitten by this mess too.  :)