### PR TITLE
Remove phrase on Cypress fetch support

### DIFF
--- a/src/routes/docs/comparison-with-other-tools.mdx
+++ b/src/routes/docs/comparison-with-other-tools.mdx
@@ -98,7 +98,7 @@ Mirage recommends writing UI tests at a single level of abstraction, usually foc
 
 These differences are just about Cypress' HTTP mocking layer though – overall, we're big fans of Cypress! And Mirage works great when used as the API mocking layer right alongside your Cypress testing code. In fact, <Link to='/quickstarts/cypress/'>we even have a Quickstart guide on getting Mirage set up in a Cypress app</Link>!
 
-Other differences include the fact that Cypress' API mocks are typically not shared in development, which is a big part of Mirage's core value offering. Additionally, as of this writing, Cypress doesn't intercept `fetch` requests, whereas Mirage does.
+Other differences include the fact that Cypress' API mocks are typically not shared in development, which is a big part of Mirage's core value offering.
 
 ---
 


### PR DESCRIPTION
As of Cypress 6, `cy.intercept()` supports the Fetch API. The now deprecated commands, namely `cy.server()` and `cy.route()`, only support XMLHttpRequests. These deprecated commands may be removed in future Cypress releases.