### PR TITLE
Change the link for tutorial final result

### DIFF
--- a/src/routes/tutorial/intro.mdx
+++ b/src/routes/tutorial/intro.mdx
@@ -9,7 +9,7 @@ There is no real API server running, so the app doesn't work to start. As you im
 
 Here's an example of the final result:
 
-[**mirage-tutorial.now.sh**](https://mirage-tutorial.now.sh) ([source](https://github.com/miragejs/tutorial))
+[**mirage-tutorial.vercel.app**](https://mirage-tutorial.vercel.app) ([source](https://github.com/miragejs/tutorial))
 
 ## Setup
 


### PR DESCRIPTION
Since Vercel now uses `.vercel.app` instead of `.now.sh`, I thought it'd be nice to have the URL updated